### PR TITLE
👽️ Use full length 0x0 for simpler firestore query

### DIFF
--- a/common/constant/index.js
+++ b/common/constant/index.js
@@ -1,6 +1,6 @@
 export const { IS_TESTNET } = process.env;
 
-export const ETH_LOCK_ADDRESS = '0x0';
+export const ETH_LOCK_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 export const ETH_MIN_LIKECOIN_AMOUNT = '1000000000000000000';
 


### PR DESCRIPTION
Seems our db receive the eth tx with a full length `0x0` from and we are using exact query for polling
not sure if there are smarter way to solve this